### PR TITLE
Update for all Laravel 5 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x"
+        "illuminate/support": "5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Not sure if it'll break anything in the future with laravel versions > 5.1, but it seems to work well still since all it needs from support is Facades and Service Providers which haven't changed so far, and I don't see them changing in the future.