### PR TITLE
Fully fixed the disable https config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ return [
     /*
      *  API Key (http://steamcommunity.com/dev/apikey)
      */
-    'api_key' => 'Your API Key'
-
+    'api_key' => 'Your API Key',
+    /*
+     * Is using https?
+     */
+    'https' => false
 ];
 
 ```

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -121,7 +121,7 @@ class SteamAuth implements SteamAuthInterface {
             }
         }
         else {
-            $return = url('/', [], false);
+            $return = url('/', [], \Config::get('steam-auth.https'));
         }
 
         $params = array(

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -38,7 +38,7 @@ class SteamAuth implements SteamAuthInterface {
     public function __construct(Request $request)
     {
         $this->request = $request;
-        $this->authUrl = $this->buildUrl(url(\Config::get('steam-auth.redirect_url')));
+        $this->authUrl = $this->buildUrl(url(\Config::get('steam-auth.redirect_url'), [], \Config::get('steam-auth.https')));
     }
 
     /**
@@ -121,14 +121,14 @@ class SteamAuth implements SteamAuthInterface {
             }
         }
         else {
-            $return = url('/');
+            $return = url('/', [], false);
         }
-        $https = $this->request->server('HTTPS');
+
         $params = array(
             'openid.ns' => 'http://specs.openid.net/auth/2.0',
             'openid.mode' => 'checkid_setup',
             'openid.return_to' => $return,
-            'openid.realm' => \Config::get('https') ? 'https' : 'http' . '://' . $this->request->server('HTTP_HOST'),
+            'openid.realm' => \Config::get('steam-auth.https') ? 'https' : 'http' . '://' . $this->request->server('HTTP_HOST'),
             'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
             'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
         );


### PR DESCRIPTION
I think the author of PR #17 didn't test it through, the code didn't even work. 

Like \Config::get('https') should be \Config::get('steam-auth.https') and the fact that he missed some url function calls where he should've used the config too.

Fixed them in this pr, also updated the config in the readme.