### PR TITLE
Fix provider register causing error on non-http usage (tests, etc...)

### DIFF
--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -50,8 +50,12 @@ class SteamAuth implements SteamAuthInterface
      * @param Request $request
      * @return void
      */
-    public function __construct(Request $request)
+    public function __construct(Request $request = null)
     {
+        if (!$request) {
+            $request = new Request();
+        }
+        
         $this->request = $request;
         $this->authUrl = $this->buildUrl(url(Config::get('steam-auth.redirect_url'), [],
             Config::get('steam-auth.https')));


### PR DESCRIPTION
Seems like this was reported on Issue #38.

I don't agree 100% the way I fixed it, but it's simple enough to fix something that causes lots of issues.