### PR TITLE
Using singleton for loading the library

### DIFF
--- a/src/SteamServiceProvider.php
+++ b/src/SteamServiceProvider.php
@@ -28,11 +28,9 @@ class SteamServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['steamauth'] = $this->app->share(
-            function () {
-                return new SteamAuth();
-            }
-        );
+        $this->app->singleton('steamauth', function () {
+            return new SteamAuth();
+        });
     }
 
 }


### PR DESCRIPTION
Fix for #43.

The `singleton` method has existed since 5.0, so this does not break anything. Just adds compatibility for 5.4 