### PR TITLE
Added App Request when creating new SteamAuth object.

### DIFF
--- a/src/SteamServiceProvider.php
+++ b/src/SteamServiceProvider.php
@@ -29,7 +29,7 @@ class SteamServiceProvider extends ServiceProvider {
     public function register()
     {
         $this->app->singleton('steamauth', function () {
-            return new SteamAuth();
+            return new SteamAuth($this->app->request);
         });
     }
 


### PR DESCRIPTION
I forced next error:
```
 [Symfony\Component\Debug\Exception\FatalThrowableError]
  Type error: Argument 1 passed to Invisnik\LaravelSteamAuth\SteamAuth::__con
  struct() must be an instance of Illuminate\Http\Request, none given, called
   in /vendor/invisnik/laravel-steam-auth/src/SteamServiceProvider.php on line 33
```
on generating ide-helper meta for my project.

Also fix #38 .
