### PR TITLE
Do not depend on the whole Laravel framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "laravel/framework": "5.*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2",
+        "illuminate/http": "5.*",
+        "illuminate/routing": "5.*",
+        "illuminate/support": "5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.0"

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -30,7 +30,7 @@ class SteamAuth implements SteamAuthInterface
     private $request;
 
     /**
-     * @var GuzzleHttp\Client
+     * @var GuzzleClient
      */
     private $guzzleClient;
 
@@ -48,7 +48,6 @@ class SteamAuth implements SteamAuthInterface
      * Create a new SteamAuth instance
      *
      * @param Request $request
-     * @return void
      */
     public function __construct(Request $request)
     {


### PR DESCRIPTION
Currently, this module depends on the whole Laravel framework, and I'm not sure why.

This actually disrupts Lumen only installations where people want to have a smaller application footprint.