### PR TITLE
Allow a steam return url to be passed through

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ class AuthController extends Controller
 
 Should you wish to use a login redirection URL that is differant from the one you specified in the config
 
-```
+```php
     public function __construct(Request $request)
     {
         $this->steam = new SteamAuth($request, '/redirect/path');

--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ class AuthController extends Controller
 Should you wish to use a login redirection URL that is differant from the one you specified in the config
 
 ```php
-public function __construct(Request $request)
-{
-    $this->steam = new SteamAuth($request, '/redirect/path');
-}
+// Inside your controller login method
+$this->$steam->setRedirectUrl(route('login.route'));
+
+...
+
+return $this->$steam->redirect();
 ```

--- a/README.md
+++ b/README.md
@@ -99,3 +99,12 @@ class AuthController extends Controller
 }
 
 ```
+
+Should you wish to use a login redirection URL that is differant from the one you specified in the config
+
+```
+    public function __construct(Request $request)
+    {
+        $this->steam = SteamAuth($request, '/redirect/path');
+    }
+```

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ class AuthController extends Controller
 Should you wish to use a login redirection URL that is differant from the one you specified in the config
 
 ```php
-    public function __construct(Request $request)
-    {
-        $this->steam = new SteamAuth($request, '/redirect/path');
-    }
+public function __construct(Request $request)
+{
+    $this->steam = new SteamAuth($request, '/redirect/path');
+}
 ```

--- a/README.md
+++ b/README.md
@@ -105,6 +105,6 @@ Should you wish to use a login redirection URL that is differant from the one yo
 ```
     public function __construct(Request $request)
     {
-        $this->steam = SteamAuth($request, '/redirect/path');
+        $this->steam = new SteamAuth($request, '/redirect/path');
     }
 ```

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Should you wish to use a login redirection URL that is differant from the one yo
 
 ```php
 // Inside your controller login method
-$this->$steam->setRedirectUrl(route('login.route'));
+$this->steam->setRedirectUrl(route('login.route'));
 
 ...
 

--- a/README.md
+++ b/README.md
@@ -169,5 +169,5 @@ $this->$steam->setRedirectUrl(route('login.route'));
 
 ...
 
-return $this->$steam->redirect();
+return $this->steam->redirect();
 ```

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -49,14 +49,14 @@ class SteamAuth implements SteamAuthInterface
      *
      * @param Request $request
      */
-    public function __construct(Request $request, $redirect_url = null)
+    public function __construct(Request $request)
     {
         $this->request = $request;
-        if(!$redirect_url){
-            $redirect_url = Config::get('steam-auth.redirect_url');
-        }
+        
+        $redirect_url = Config::get('steam-auth.redirect_url');
         $this->authUrl = $this->buildUrl(url($redirect_url, [],
             Config::get('steam-auth.https')));
+        
         $this->guzzleClient = new GuzzleClient;
     }
 
@@ -186,6 +186,19 @@ class SteamAuth implements SteamAuthInterface
 
         return self::OPENID_URL . '?' . http_build_query($params, '', '&');
     }
+    
+    /**
+     * Set the url to return to.
+     *
+     * @param string $url Full URL to redirect to on Steam login
+     *
+     * @return void
+     */
+    public function setRedirectUrl($url)
+    {
+           $this->authUrl = $this->buildUrl($url);
+    }
+    
 
     /**
      * Returns the redirect response to login

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -50,10 +50,13 @@ class SteamAuth implements SteamAuthInterface
      * @param Request $request
      * @return void
      */
-    public function __construct(Request $request)
+    public function __construct(Request $request, $redirect_url = null)
     {
         $this->request = $request;
-        $this->authUrl = $this->buildUrl(url(Config::get('steam-auth.redirect_url'), [],
+        if(!$redirect_url){
+            $redirect_url = Config::get('steam-auth.redirect_url');
+        }
+        $this->authUrl = $this->buildUrl(url($redirect_url, [],
             Config::get('steam-auth.https')));
         $this->guzzleClient  = new GuzzleClient;
     }


### PR DESCRIPTION
Sometimes (I have found in my application, anyway) it is useful to push the user from one url, and have them return to another one that is not the same as that specified in the config.

Simply allows a URL to be passed through when constructing the SteamAuth class.