### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,33 @@
 language: php
-php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - hhvm
 
-before_script:
+## Run on container environment
+sudo: false
+
+## Cache composer bits
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+## List all PHP versions to test with
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - hhvm
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+    - php: hhvm
+
+## Install Dependencies
+install:
   - composer self-update
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit
+## Run test Scripts
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
 install:
   - composer self-update
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
 ## Run test Scripts
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: php
 ## Run on container environment
 sudo: false
 
+## Run on ubuntu trusty
+dist: trusty
+
 ## Cache composer bits
 cache:
   directories:


### PR DESCRIPTION
Use more travis features and allow failures in nightly and hhvm builds. You also can add a GitHub Token in travis settings as GH_TOKEN. It also uses the new container build and uses the composer cache.