### PR TITLE
add env Steam API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Add this to your `composer.json` file, in the require object:
 
 After that, run `composer install` to install the package.
 
+#### Laravel 5.4 and below
+
 Add the service provider to `app/config/app.php`, within the `providers` array.
 
 ```php
@@ -23,6 +25,18 @@ Add the service provider to `app/config/app.php`, within the `providers` array.
 	Invisnik\LaravelSteamAuth\SteamServiceProvider::class,
 ]
 ```
+
+Package is automatically added if you are in Laravel 5.5
+
+#### Steam API Key
+
+Add your Steam API key to your `.env` file. You can your API key [here](http://steamcommunity.com/dev/apikey).
+
+```
+STEAM_API_KEY=SomeKindOfAPIKey
+```
+
+#### Config Files
 
 Lastly, publish the config file.
 
@@ -39,9 +53,9 @@ return [
      */
     'redirect_url' => '/login',
     /*
-     *  API Key (http://steamcommunity.com/dev/apikey)
+     *  API Key (set in .env file) [http://steamcommunity.com/dev/apikey]
      */
-    'api_key' => 'Your API Key',
+    'api_key' => env('STEAM_API_KEY', ''),
     /*
      * Is using https?
      */

--- a/config/config.php
+++ b/config/config.php
@@ -7,9 +7,9 @@ return [
      */
     'redirect_url' => '/',
     /*
-     * API Key (http://steamcommunity.com/dev/apikey)
+     * API Key (set in .env file) [http://steamcommunity.com/dev/apikey]
      */
-    'api_key' => 'API_Key',
+    'api_key' => env('STEAM_API_KEY', ''),
     /*
      * Is using https ?
      */

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -1,6 +1,6 @@
 <?php namespace Invisnik\LaravelSteamAuth;
 
-use Exception;
+use RuntimeException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use GuzzleHttp\Client as GuzzleClient;
@@ -169,7 +169,7 @@ class SteamAuth implements SteamAuthInterface
             $return = url('/', [], Config::get('steam-auth.https'));
         }
         if (!is_null($return) && !$this->validateUrl($return)) {
-            throw new Exception('The return URL must be a valid URL with a URI Scheme or http or https.');
+            throw new RuntimeException('The return URL must be a valid URL with a URI Scheme or http or https.');
         }
 
         $params = array(
@@ -213,6 +213,10 @@ class SteamAuth implements SteamAuthInterface
     public function parseInfo()
     {
         if (is_null($this->steamId)) return;
+
+        if(!empty(Config::get('steam-auth.api_key'))) {
+            throw new RuntimeException('The Steam API key has not been specified.');
+        }
 
         $reponse = $this->guzzleClient->request('GET', sprintf(self::STEAM_INFO_URL, Config::get('steam-auth.api_key'), $this->steamId));
         $json = json_decode($reponse->getBody(), true);

--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -214,7 +214,7 @@ class SteamAuth implements SteamAuthInterface
     {
         if (is_null($this->steamId)) return;
 
-        if(!empty(Config::get('steam-auth.api_key'))) {
+        if(empty(Config::get('steam-auth.api_key'))) {
             throw new RuntimeException('The Steam API key has not been specified.');
         }
 


### PR DESCRIPTION
Makes config pull from the `.env` file so API keys are not pushed to someone's version control. Also added that an exception is thrown when the API key is not set. The readme is also updated.