### PR TITLE
remove deprecated linting

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,3 @@
 preset: laravel
 
 risky: false
-
-linting: true


### PR DESCRIPTION
https://styleci.readme.io/docs/change-log#section-14042018-april-fixer-updates
> Finally, the long deprecated "linting" config option has now been removed.