### PR TITLE
Custom request options for Guzzle.

### DIFF
--- a/src/SteamAuth.php
+++ b/src/SteamAuth.php
@@ -2,9 +2,9 @@
 
 namespace Invisnik\LaravelSteamAuth;
 
-use GuzzleHttp\RequestOptions;
 use RuntimeException;
 use Illuminate\Http\Request;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Fluent;
 use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Support\Facades\Config;
@@ -115,7 +115,7 @@ class SteamAuth implements SteamAuthInterface
         $requestOptions = $this->getDefaultRequestOptions();
         $customOptions = $this->getCustomRequestOptions();
 
-        if (!empty($customOptions) && is_array($customOptions)) {
+        if (! empty($customOptions) && is_array($customOptions)) {
             $requestOptions = array_merge($requestOptions, $customOptions);
         }
 
@@ -315,6 +315,7 @@ class SteamAuth implements SteamAuthInterface
             RequestOptions::FORM_PARAMS => $this->getParams(),
         ];
     }
+
     /**
      * If you need to set additional guzzle options on request,
      * set them via this method.


### PR DESCRIPTION
I need to send requests to Steam via another ethernet interface (proxy IP). For this I need to pass 'CURL' option in Guzzle parameters on request. For example:

`'curl' => [ CURLOPT_INTERFACE => xxx.xxx.xxx.xxx ]`

But currently there are no options to do this.

I've added new property and method to handle this. Maybe someone will need other options to add. Also if user do not use this method, nothing change for him.

Also some duplicate strings updated to constants.